### PR TITLE
Update telemeter-service manifests path

### DIFF
--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,7 +1,7 @@
 services:
 - hash: 61bd696f0271c44c5566668fd5b9a33fcfd482d3
   name: telemeter-server
-  path: /deploy/telemeter-server.yaml
+  path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter
   hash_length: 7
   environments:

--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 61bd696f0271c44c5566668fd5b9a33fcfd482d3
+- hash: 64a290d15a6274632af07c5dd553e1bc56febb06
   name: telemeter-server
   path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter


### PR DESCRIPTION
This updates the manifests from the old ones in `/deploy/` to the ones in `/manifests/server/`

@jmelis PTAL