### PR TITLE
[WIP] Add telemeter-prometheus manifests

### DIFF
--- a/telemeter-services/telemeter-prometheus.yaml
+++ b/telemeter-services/telemeter-prometheus.yaml
@@ -1,0 +1,8 @@
+services:
+- name: telemeter-prometheus
+  path: /manifests/prometheus/list.yaml
+  url: https://github.com/openshift/telemeter
+  environments:
+  - name: production
+    parameters:
+      NAMESPACE: telemeter-production

--- a/telemeter-services/telemeter-prometheus.yaml
+++ b/telemeter-services/telemeter-prometheus.yaml
@@ -1,7 +1,9 @@
 services:
-- name: telemeter-prometheus
+- hash: 64a290d15a6274632af07c5dd553e1bc56febb06
+  name: telemeter-prometheus
   path: /manifests/prometheus/list.yaml
   url: https://github.com/openshift/telemeter
+  hash_length: 7
   environments:
   - name: production
     parameters:


### PR DESCRIPTION
This adds a telemeter-prometheus service

One difference compared to the other services we provision with saas-herder is that we don't really track an image/tag here. The image/tag is handled by the operator. We could potentially track those but even if we were to do so, the tags aren't hashes so that wouldn't work I think.

Another important consideration is that we need to ensure the secrets (and configmaps?) are properly ignored when applying the template as we don't want to overwrite the real secrets.

@jmelis any thoughts on how we can accomplish/validate the above?