### PR TITLE
Add prometheus-operator template, rename prometheus-telemeter

### DIFF
--- a/homeless-templates/prometheus-operator.yaml
+++ b/homeless-templates/prometheus-operator.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: prometheus
+spec:
+  channel: preview
+  name: prometheus
+  source: rh-operators
+  #startingCSV: prometheusoperator.0.22.2

--- a/homeless-templates/prometheus-operator.yaml
+++ b/homeless-templates/prometheus-operator.yaml
@@ -1,10 +1,15 @@
 ---
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
+apiVersion: v1
+kind: Template
 metadata:
-  name: prometheus
-spec:
-  channel: preview
-  name: prometheus
-  source: rh-operators
-  #startingCSV: prometheusoperator.0.22.2
+  name: prometheus-operator
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: prometheus
+  spec:
+    channel: preview
+    name: prometheus
+    source: rh-operators
+    #startingCSV: prometheusoperator.0.22.2

--- a/telemeter-services/prometheus-operator.yaml
+++ b/telemeter-services/prometheus-operator.yaml
@@ -1,11 +1,6 @@
 services:
-- hash: 2f87cf149520c93e8ab41778e18cea3e8fddb2f8
+- hash: master
   name: prometheus-operator
-  path: /manifests/prometheus/list.yaml
-  url: https://github.com/openshift/telemeter
+  path: /homeless-templates/prometheus-operator.yaml
+  url: https://github.com/app-sre/saas-telemeter
   hash_length: 7
-  environments:
-  - name: production
-    parameters:
-      NAMESPACE: telemeter-production
-      IMAGE_TAG: v2.3.2

--- a/telemeter-services/prometheus-telemeter.yaml
+++ b/telemeter-services/prometheus-telemeter.yaml
@@ -1,0 +1,11 @@
+services:
+- hash: 2f87cf149520c93e8ab41778e18cea3e8fddb2f8
+  name: prometheus-telemeter
+  path: /manifests/prometheus/list.yaml
+  url: https://github.com/openshift/telemeter
+  hash_length: 7
+  environments:
+  - name: production
+    parameters:
+      NAMESPACE: telemeter-production
+      IMAGE_TAG: v2.3.2


### PR DESCRIPTION
What this PR does:
- prometheus-operator service to prometheus-telemeter to match deployment artifacts names
- move prometheus-telemeter service to it's own prometheus-telemeter.yaml file
- Add prometheus-operator service
- Add prometheus-operator homeless template