### PR TITLE
Use telemeter image from the app-sre repo

### DIFF
--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 18db464dfa599cb5aaa06041613f0164fe9ccf17
+- hash: 0d72336d394368d42aef39a492e852ca72d1eb74
   name: telemeter-server
   path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter

--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,15 +1,8 @@
 services:
-- hash: 1ffafc8949db1d7af222a676edacc5238101e678
+- hash: 18db464dfa599cb5aaa06041613f0164fe9ccf17
   name: telemeter-server
   path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter
   hash_length: 7
-  environments:
-  - name: production
-    parameters:
-      IMAGE: quay.io/openshift/origin-telemeter
-      IMAGE_TAG: v4.0.0
-      AUTHORIZE_URL: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
-  - name: staging
-    parameters:
-      IMAGE: quay.io/app-sre/telemeter
+  parameters:
+    IMAGE: quay.io/app-sre/telemeter


### PR DESCRIPTION
Use quay.io/app-sre/telemeter both in production and staging.

AUTHORIZE_URL has been removed because it matches the default definition
in the template.

IMAGE_TAG is a special variable, and if ommited from the saasherder's
configuration, it will be dynamically calculated based on the git
commit.