### PR TITLE
telemeter-services: update telemeter server deployment

### DIFF
--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: ac67628fab155d27d684f83fcb23df3c9870aa8c
+- hash: 0f39a2a115b64b4a795b10297fbbc614c92964b5
   name: telemeter-server
   path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter


### PR DESCRIPTION
This commit bumps the deployment of Telemeter server to a hash where the
manifests are configured with a higher ratelimit and more replicas.