### PR TITLE
telemeter-services: bump hash to raise rate-limit

### DIFF
--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0f39a2a115b64b4a795b10297fbbc614c92964b5
+- hash: cff122183d87bde0ed6245ba16f3d2331c542d62
   name: telemeter-server
   path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter


### PR DESCRIPTION
corresponds to https://github.com/openshift/telemeter/pull/117

cc @jmelis @riuvshin 