### PR TITLE
telemeter: reset rate-limit

### DIFF
--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: cff122183d87bde0ed6245ba16f3d2331c542d62
+- hash: 2237318f746c63d4a6b848f38aa99c92d1d26b49
   name: telemeter-server
   path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter


### PR DESCRIPTION
cc @jmelis @aditya-konarde @riuvshin 

It turns out the ratelimiting issues were due to Tollbooth, not
Telemeter so we can reset the Telemeter manifests to use the
default ratelimit.