### PR TITLE
telemeter-service: fix whitelist value

### DIFF
--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2237318f746c63d4a6b848f38aa99c92d1d26b49
+- hash: e02b7b1092db3e256c5bdd144bd165e007715e2d
   name: telemeter-server
   path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter


### PR DESCRIPTION
This commit replaces the string ALERTS with alerts in the server's
whitelist to accept the metric that is automatically renamed on the
client.

xref https://github.com/openshift/telemeter/pull/119
cc @riuvshin @jmelis @jfchevrette