### PR TITLE
Revert telemeter staging deploy back to app-sre-dev cluster

### DIFF
--- a/telemeter-services/prometheus-telemeter.yaml
+++ b/telemeter-services/prometheus-telemeter.yaml
@@ -11,5 +11,5 @@ services:
       PROMETHEUS_IMAGE_TAG: v2.3.2
   - name: staging
     parameters:
-      NAMESPACE: telemeter-stage
+      NAMESPACE: telemeter-staging
       PROMETHEUS_IMAGE_TAG: v2.3.2

--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -11,5 +11,5 @@ services:
       IMAGE: quay.io/app-sre/telemeter
   - name: staging
     parameters:
-      NAMESPACE: telemeter-stage
+      NAMESPACE: telemeter-staging
       IMAGE: quay.io/app-sre/telemeter


### PR DESCRIPTION
Deploy blocks on RoleBinding object being applied before the Role in the template

Reverts app-sre/saas-telemeter#30