### PR TITLE
Add AUTHORIZE_URL parameter

### DIFF
--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -9,7 +9,9 @@ services:
     parameters:
       NAMESPACE: telemeter-production
       IMAGE: quay.io/app-sre/telemeter
+      AUTHORIZE_URL: https://api.openshift.com/api/accounts_mgmt/v1/cluster_registrations
   - name: staging
     parameters:
       NAMESPACE: telemeter-stage
       IMAGE: quay.io/app-sre/telemeter
+      AUTHORIZE_URL: https://api.stage.openshift.com/api/accounts_mgmt/v1/cluster_registrations


### PR DESCRIPTION
This sets the AUTHORIZE_URL parameter for staging so that it does not connect to the production endpoints which is the default. It also sets it for production for clarity even though that will result in the same config

@s-urbaniak PTAL