### PR TITLE
telemeter-services/telmeter-server: bump hash

### DIFF
--- a/telemeter-services/telemeter-server.yaml
+++ b/telemeter-services/telemeter-server.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e7a298cf835a1317d369a8df457e214efe51ecbd
+- hash: efc4bdd10d6fa8b790e8d948ea952c2931dc70bd
   name: telemeter-server
   path: /manifests/server/list.yaml
   url: https://github.com/openshift/telemeter


### PR DESCRIPTION
Changes:

- PR https://github.com/openshift/telemeter/pull/150:
pkg/authorize/tollbooth: handle 404 - cluster not found

cc @brancz @aditya-konarde @squat