### PR TITLE
telemeter-services: fix prom session affinity

### DIFF
--- a/telemeter-services/prometheus-telemeter.yaml
+++ b/telemeter-services/prometheus-telemeter.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 89dca9908ae4597f61db10d3928fd9a2d06e5df9
+- hash: 6fa6a7234b311a247c40602126b31c8254a3cdc3
   name: prometheus-telemeter
   path: /manifests/prometheus/list.yaml
   url: https://github.com/openshift/telemeter
@@ -9,10 +9,10 @@ services:
     parameters:
       NAMESPACE: telemeter-production
       PROMETHEUS_IMAGE_TAG: v2.3.2
-      #PROMETHEUS_CPU_REQUEST: 100m
-      #PROMETHEUS_CPU_LIMIT: 1
-      #PROMETHEUS_MEMORY_REQUEST: 500Mi
-      #PROMETHEUS_MEMORY_LIMIT: 8Gi
+      PROMETHEUS_CPU_REQUEST: 100m
+      PROMETHEUS_CPU_LIMIT: 1
+      PROMETHEUS_MEMORY_REQUEST: 500Mi
+      PROMETHEUS_MEMORY_LIMIT: 8Gi
   - name: staging
     parameters:
       NAMESPACE: telemeter-stage


### PR DESCRIPTION
This commit fixes the session affinity for the Prometheus route.

cc @jfchevrette 